### PR TITLE
Adjust parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,7 @@ input:
 | `variant_caller`                    | string | Variant calling algorithm used to generate input VCF (HaplotypeCaller, Mutect2, Strelka2, SomaticSniper, Muse2, Delly2).        |
 | `rf_model`                          | path   | Path to corresponding pre-trained random forest model.                                                                          |
 | `funcotator_data.data_source`       | path   | Path to Funcotator data source directory.                                                                                       |
-| `funcotator_data.src_reference_id`  | string | Reference genome build ID for input VCF (hg19, hg38).                                                                           |
-| `funcotator_data.dest_reference_id` | string | Reference genome build ID for output VCF (hg19, hg38).                                                                          |
+| `source_build`                      | string | Reference genome build of input VCF (GRCh37 or GRCh38).                                                                         |
 | `src_fasta_ref`                     | path   | Path to the source reference sequence in FASTA format. Must correspond with `functotator_data.src_reference_id`.                |
 | `dest_fasta_ref`                    | path   | Path to the destination reference sequence in FASTA format. Must correspond with `functotator_data.dest_reference_id`.          |
 | `chain_file`                        | path   | Path to LiftOver chain file between the source and destination sequences.                                                       |


### PR DESCRIPTION
I think since we're running all the annotations in GRCh38, we can replace these two Funcotator parameters with just `source_build`? Let me know if I'm overlooking something.