### PR TITLE
Simplify input parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Sort VCF after liftover in SV branch
+- Hide parametric complexity behind simpler user inputs

--- a/config/default.config
+++ b/config/default.config
@@ -30,14 +30,6 @@ params {
     docker_image_pipeval = "${-> params.docker_container_registry}/pipeval:${params.pipeval_version}"
     docker_image_samtools = "${-> params.docker_container_registry}/samtools:${params.samtools_version}"
     docker_image_stablelift = "${-> params.docker_container_registry}/stablelift:${params.stablelift_version}"
-
-    // These are the index files associated with the source and destination
-    // reference sequences
-    src_fasta_fai = "${ -> params.src_fasta_ref}.fai"
-    dest_fasta_fai = "${ -> params.dest_fasta_ref}.fai"
-
-    src_fasta_dict = "${ -> Nextflow.file(params.src_fasta_ref).resolveSibling(Nextflow.file(params.src_fasta_ref).getBaseName() + '.dict') }"
-    dest_fasta_dict = "${ -> Nextflow.file(params.dest_fasta_ref).resolveSibling(Nextflow.file(params.dest_fasta_ref).getBaseName() + '.dict') }"
 }
 
 // Process specific scope

--- a/config/methods.config
+++ b/config/methods.config
@@ -4,6 +4,8 @@ includeConfig "${projectDir}/external/pipeline-Nextflow-config/config/schema/sch
 includeConfig "${projectDir}/external/pipeline-Nextflow-config/config/bam/bam_parser.config"
 includeConfig "${projectDir}/external/pipeline-Nextflow-config/config/store_object_as_json/store_object_as_json.config"
 
+import nextflow.Nextflow
+
 methods {
     // Set the output and log output dirs here.
     set_output_dir = {
@@ -37,19 +39,57 @@ methods {
         }
     }
 
-    determine_liftover_direction = {
-        if (params.funcotator_data.src_reference_id == params.funcotator_data.dest_reference_id) {
-            throw new IllegalArgumentException("params.funcotator_data.src_reference_id and params.funcotator_data.dest_reference_id must be different!")
+    expand_parameters = {
+        // Make sure the user didn't set any of the advanced parameters
+        def advanced_parameters = [
+            'src_fasta_id',
+            'src_fasta_ref',
+            'src_fasta_fai',
+            'src_fasta_dict',
+            'dest_fasta_id',
+            'dest_fasta_ref',
+            'dest_fasta_fai',
+            'dest_fasta_dict'
+        ]
+
+        for (key in advanced_parameters) {
+            if (params.containsKey(key)) {
+                throw new Exception("Do not directly set params.${key} - the value will be inferred from params.liftover_direction")
+            }
         }
 
-        if (![params.funcotator_data.src_reference_id, params.funcotator_data.dest_reference_id].contains("hg38")) {
-            throw new IllegalArgumentException("One of params.funcotator_data.src_reference_id and params.funcotator_data.dest_reference_id must be 'hg38'!")
-        }
+        def liftover_direction  = params.getOrDefault('liftover_direction', null)
 
-        params.liftover_forward = params.funcotator_data.dest_reference_id == "hg38"
+        def forward  = "GRCh37ToGRCh38"
+        def backward = "GRCh38ToGRCh37"
+
+        if (liftover_direction in [forward, backward]) {
+            if (liftover_direction == forward) {
+                params.src_fasta_id = 'hg19'
+                params.src_fasta_ref = params.fasta_ref_37
+
+                params.dest_fasta_id = 'hg38'
+                params.dest_fasta_ref = params.fasta_ref_38
+            } else {
+                params.src_fasta_id = 'hg38'
+                params.src_fasta_ref = params.fasta_ref_38
+
+                params.dest_fasta_id = 'hg19'
+                params.dest_fasta_ref = params.fasta_ref_37
+            }
+
+            params.src_fasta_fai = params.src_fasta_ref + ".fai"
+            params.dest_fasta_fai = params.dest_fasta_ref + ".fai"
+
+            params.src_fasta_dict = Nextflow.file(params.src_fasta_ref).resolveSibling(Nextflow.file(params.src_fasta_ref).getBaseName() + '.dict').toString()
+            params.dest_fasta_dict = Nextflow.file(params.dest_fasta_ref).resolveSibling(Nextflow.file(params.dest_fasta_ref).getBaseName() + '.dict').toString()
+        }
     }
 
+
     setup = {
+        methods.expand_parameters()
+
         schema.load_custom_types("${projectDir}/config/custom_schema_types.config")
         schema.validate()
 
@@ -60,8 +100,6 @@ methods {
         methods.set_env()
         methods.setup_docker_cpus()
         methods.setup_process_afterscript()
-
-        methods.determine_liftover_direction()
 
         json_extractor.store_object_as_json(
             params,

--- a/config/methods.config
+++ b/config/methods.config
@@ -93,6 +93,13 @@ methods {
         schema.load_custom_types("${projectDir}/config/custom_schema_types.config")
         schema.validate()
 
+        // Validate the branch-specific parameters
+        if (params.variant_caller == "Delly2") {
+            schema.validate("${projectDir}/config/schema-sv.yaml")
+        } else {
+            schema.validate("${projectDir}/config/schema-snv.yaml")
+        }
+
         methods.set_output_dir()
         methods.set_resources_allocation()
         methods.modify_base_allocations()

--- a/config/schema-snv.yaml
+++ b/config/schema-snv.yaml
@@ -9,4 +9,4 @@ funcotator_data_source:
   type: 'Path'
   required: true
   mode: 'r'
-  help: 'Root data source folder for Funcotator'
+  help: 'Root data source folder for Funcotator from https://gatk.broadinstitute.org/hc/en-us/articles/360035889931-Funcotator-Information-and-Tutorial'

--- a/config/schema-snv.yaml
+++ b/config/schema-snv.yaml
@@ -10,4 +10,3 @@ funcotator_data_source:
   required: true
   mode: 'r'
   help: 'Root data source folder for Funcotator'
-

--- a/config/schema-snv.yaml
+++ b/config/schema-snv.yaml
@@ -3,7 +3,7 @@ repeat_bed:
   type: 'Path'
   mode: 'r'
   required: true
-  help: 'FIXME ???'
+  help: 'RepeatMasker (v3.0.1) intervals from UCSC Table Browser for variant annotation in GRCh38 coordinates, included in resource-bundle.zip'
 
 funcotator_data_source:
   type: 'Path'

--- a/config/schema-snv.yaml
+++ b/config/schema-snv.yaml
@@ -1,0 +1,13 @@
+---
+repeat_bed:
+  type: 'Path'
+  mode: 'r'
+  required: true
+  help: 'FIXME ???'
+
+funcotator_data_source:
+  type: 'Path'
+  required: true
+  mode: 'r'
+  help: 'Root data source folder for Funcotator'
+

--- a/config/schema-sv.yaml
+++ b/config/schema-sv.yaml
@@ -3,10 +3,10 @@ header_contigs:
   type: 'Path'
   mode: 'r'
   required: true
-  help: 'FIXME ???'
+  help: 'VCF header contigs of target build for LiftOver conversion, included in resource-bundle.zip'
 
 gnomad_rds:
   type: 'Path'
   mode: 'r'
   required: true
-  help: 'FIXME ???'
+  help: 'Pre-processed gnomAD-SV (v4) data.table (.Rds) for annotating population allele frequency, included in resource-bundle.zip'

--- a/config/schema-sv.yaml
+++ b/config/schema-sv.yaml
@@ -1,0 +1,12 @@
+---
+header_contigs:
+  type: 'Path'
+  mode: 'r'
+  required: true
+  help: 'FIXME ???'
+
+gnomad_rds:
+  type: 'Path'
+  mode: 'r'
+  required: true
+  help: 'FIXME ???'

--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -2,12 +2,12 @@
 sample_id:
   type: 'String'
   required: true
-  help: 'sample id supplied from input yaml'
+  help: 'Sample id supplied from input yaml'
 
 liftover_direction:
   type: 'String'
   required: true
-  help: 'Direction of liftover to perform'
+  help: 'Direction of LiftOver to perform'
   choices:
     - GRCh37toGRCh38
     - GRCh38toGRCh37
@@ -15,7 +15,7 @@ liftover_direction:
 variant_caller:
   type: 'String'
   required: true
-  help: 'Tool used to call structural or somatic variants'
+  help: 'Tool used to call variants'
   choices:
     - Mutect2
     - HaplotypeCaller
@@ -34,7 +34,7 @@ output_dir:
   type: 'Path'
   mode: 'w'
   required: true
-  help: 'absolute path to directory to store output'
+  help: 'Absolute path to directory to store output'
 
 fasta_ref_37:
   type: 'Path'
@@ -88,13 +88,13 @@ chain_file:
   type: 'Path'
   mode: 'r'
   required: true
-  help: 'FIXME ???'
+  help: 'Chain file corresponding to LiftOver direction, included in resource-bundle.zip'
 
 rf_model:
   type: 'Path'
   mode: 'r'
   required: true
-  help: 'FIXME ???'
+  help: 'Path to pre-trained random forest model (.Rds) corresponding to variant caller and LiftOver direction'
 
 input:
   type: 'Namespace'

--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -3,6 +3,15 @@ sample_id:
   type: 'String'
   required: true
   help: 'sample id supplied from input yaml'
+
+liftover_direction:
+  type: 'String'
+  required: true
+  help: 'Direction of liftover to perform'
+  choices:
+    - GRCh37toGRCh38
+    - GRCh38toGRCh37
+
 variant_caller:
   type: 'String'
   required: true

--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -23,81 +23,79 @@ variant_caller:
     - Muse2
     - SomaticSniper
     - Delly2
+
 save_intermediate_files:
   type: 'Bool'
   required: true
   default: false
   help: 'Enable to store intermediate files'
+
 output_dir:
   type: 'Path'
   mode: 'w'
   required: true
   help: 'absolute path to directory to store output'
+
+fasta_ref_37:
+  type: 'Path'
+  mode: 'r'
+  required: true
+  help: 'GRCh37 FASTA reference'
+
+fasta_ref_38:
+  type: 'Path'
+  mode: 'r'
+  required: true
+  help: 'GRCh38 FASTA reference'
+
 src_fasta_ref:
   type: 'Path'
   mode: 'r'
   required: true
   help: 'Source reference sequence (FASTA)'
+
 src_fasta_fai:
   type: 'Path'
   mode: 'r'
   required: true
   help: 'Source reference sequence index file'
+
 src_fasta_dict:
   type: 'Path'
   mode: 'r'
   required: true
   help: 'Source reference sequence dictionary'
+
 dest_fasta_ref:
   type: 'Path'
   mode: 'r'
   required: true
   help: 'Destination reference sequence (FASTA)'
+
 dest_fasta_fai:
   type: 'Path'
   mode: 'r'
   required: true
   help: 'Destination reference sequence index file'
+
 dest_fasta_dict:
   type: 'Path'
   mode: 'r'
   required: true
   help: 'Destination reference sequence dictionary'
+
 chain_file:
   type: 'Path'
   mode: 'r'
   required: true
   help: 'FIXME ???'
-repeat_bed:
-  type: 'Path'
-  mode: 'r'
-  required: true
-  help: 'FIXME ???'
-funcotator_data:
-  type: 'FuncotatorDataSource'
-  required: true
-  help: 'Funcotator data source and reference sample IDs'
-  elements:
-    data_source:
-      type: 'Path'
-      mode: 'r'
-      required: true
-      help: 'Root data source folder for Funcotator'
-    src_reference_id:
-      type: 'String'
-      mode: 'r'
-      required: true
-      help: 'Reference build ID for the source sequence'
-    dest_reference_id:
-      type: 'String'
-      mode: 'r'
-      required: true
-      help: 'Reference build ID for the destination sequence'
+
 rf_model:
   type: 'Path'
   mode: 'r'
   required: true
   help: 'FIXME ???'
+
 input:
   type: 'Namespace'
   required: true

--- a/config/template.config
+++ b/config/template.config
@@ -27,29 +27,25 @@ params {
     // be in the range [0.0, 1.0],
     // target_specificity = 0.5
 
-    // Reference files
-    funcotator_data {
-        data_source = "/hot/ref/tool-specific-input/Funcotator/somatic/funcotator_dataSources.v1.7.20200521s"
-        src_reference_id = "hg19"
-        dest_reference_id = "hg38"
-    }
+    liftover_direction = "" // Choices: GRCh37ToGRCh38, GRCh38ToGRCh37
 
-    // The source reference sequence (FASTA). Must correspond with
-    // params.funcotator_data.src_reference_id
-    src_fasta_ref = "/hot/ref/reference/GRCh37-EBI-hs37d5/hs37d5.fa"
+    // Path to the GRCh37 reference sequence (FASTA).
+    fasta_ref_37 = "/hot/ref/reference/GRCh37-EBI-hs37d5/hs37d5.fa"
 
-    // The destination reference sequence (FASTA). Must correspond with
-    // params.funcotator_data.dest_reference_id
-    dest_fasta_ref = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    // Path to the GRCh38 reference sequence (FASTA).
+    fasta_ref_38 = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
 
     // The liftover chain file between the source and destination FASTA
     // references
     chain_file = "/hot/ref/tool-specific-input/liftOver/hg19ToHg38.over.chain"
 
+    // SNV required references
+    funcotator_data_source = "/hot/ref/tool-specific-input/Funcotator/somatic/funcotator_dataSources.v1.7.20200521s"
+
     // FIXME How to describe this file?
     repeat_bed = "/hot/ref/database/RepeatMasker-3.0.1/processed/GRCh38/GRCh38_RepeatMasker_intervals.bed"
 
-    // SV files
+    // SV required references
     // FIXME Should this be bundled?
     header_contigs = "/hot/code/nkwang/GitHub/uclahs-cds/project-method-AlgorithmEvaluation-BNCH-000142-GRCh37v38/report/manuscript/publish/GRCh38-vcf-header-contigs.txt"
 

--- a/config/template.config
+++ b/config/template.config
@@ -7,7 +7,7 @@ includeConfig "${projectDir}/nextflow.config"
 
 // Inputs/parameters of the pipeline
 params {
-    // input/output locations
+    // Output locations
     output_dir = "where/to/save/outputs/"
 
     // Choices: ["HaplotypeCaller", "Mutect2", "Strelka2", "SomaticSniper", "Muse2", "Delly2"]
@@ -36,13 +36,16 @@ params {
     fasta_ref_38 = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
 
     // The liftover chain file between the source and destination FASTA references
+    // Included in resource-bundle.zip
     chain_file = "/hot/ref/tool-specific-input/liftOver/hg19ToHg38.over.chain"
 
     // SNV required references
     funcotator_data_source = "/hot/ref/tool-specific-input/Funcotator/somatic/funcotator_dataSources.v1.7.20200521s"
+    // Included in resource-bundle.zip
     repeat_bed = "/hot/ref/database/RepeatMasker-3.0.1/processed/GRCh38/GRCh38_RepeatMasker_intervals.bed"
 
     // SV required references
+    // Included in resource-bundle.zip, choose header_contigs based on target build
     header_contigs = "/hot/code/nkwang/GitHub/uclahs-cds/project-method-AlgorithmEvaluation-BNCH-000142-GRCh37v38/report/manuscript/publish/GRCh38-vcf-header-contigs.txt"
     gnomad_rds = "/hot/code/nkwang/GitHub/uclahs-cds/project-method-AlgorithmEvaluation-BNCH-000142-GRCh37v38/report/manuscript/publish/data/gnomad.v4.0.sv.Rds"
 }

--- a/config/template.config
+++ b/config/template.config
@@ -35,21 +35,15 @@ params {
     // Path to the GRCh38 reference sequence (FASTA).
     fasta_ref_38 = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
 
-    // The liftover chain file between the source and destination FASTA
-    // references
+    // The liftover chain file between the source and destination FASTA references
     chain_file = "/hot/ref/tool-specific-input/liftOver/hg19ToHg38.over.chain"
 
     // SNV required references
     funcotator_data_source = "/hot/ref/tool-specific-input/Funcotator/somatic/funcotator_dataSources.v1.7.20200521s"
-
-    // FIXME How to describe this file?
     repeat_bed = "/hot/ref/database/RepeatMasker-3.0.1/processed/GRCh38/GRCh38_RepeatMasker_intervals.bed"
 
     // SV required references
-    // FIXME Should this be bundled?
     header_contigs = "/hot/code/nkwang/GitHub/uclahs-cds/project-method-AlgorithmEvaluation-BNCH-000142-GRCh37v38/report/manuscript/publish/GRCh38-vcf-header-contigs.txt"
-
-    // FIXME Should this be bundled?
     gnomad_rds = "/hot/code/nkwang/GitHub/uclahs-cds/project-method-AlgorithmEvaluation-BNCH-000142-GRCh37v38/report/manuscript/publish/data/gnomad.v4.0.sv.Rds"
 }
 

--- a/main.nf
+++ b/main.nf
@@ -28,6 +28,9 @@ log.info """\
 
     - input:
         dataset_id: ${params.dataset_id}
+
+        liftover_direction: ${params.liftover_direction}
+
         variant_caller: ${params.variant_caller}
         rf_model: ${params.rf_model}
 
@@ -40,14 +43,14 @@ log.info """\
         dest_fasta_dict: ${params.dest_fasta_dict}
 
         chain_file: ${params.chain_file}
-        repeat_bed: ${params.repeat_bed}
 
+    - SV only:
         header_contigs: ${params.getOrDefault('header_contigs', null)}
+        gnomad_rds: ${params.getOrDefault('gnomad_rds', null)}
 
-        funcotator_data:
-            data_source:       ${params.funcotator_data.data_source}
-            src_reference_id:  ${params.funcotator_data.src_reference_id}
-            dest_reference_id: ${params.funcotator_data.dest_reference_id}
+    - SNV only:
+        repeat_bed: ${params.getOrDefault('repeat_bed', null)}
+        funcotator_data_source: ${params.getOrDefault('funcotator_data_source', null)}
 
     - output:
         output_dir_base: ${params.output_dir_base}
@@ -90,7 +93,7 @@ def indexFile(bam_or_vcf) {
 
 Channel
     .value( [
-        params.funcotator_data.src_reference_id,
+        params.src_fasta_id,
         params.src_fasta_ref,
         params.src_fasta_fai,
         params.src_fasta_dict,
@@ -99,7 +102,7 @@ Channel
 
 Channel
     .value( [
-        params.funcotator_data.dest_reference_id,
+        params.dest_fasta_id,
         params.dest_fasta_ref,
         params.dest_fasta_fai,
         params.dest_fasta_dict

--- a/module/snv_annotations.nf
+++ b/module/snv_annotations.nf
@@ -159,7 +159,7 @@ workflow workflow_apply_snv_annotations {
     run_Funcotator_GATK(
         vcf_with_sample_id,
         dest_fasta_data,
-        Channel.value(params.funcotator_data.data_source)
+        Channel.value(params.funcotator_data_source)
     )
 
     annotate_RepeatMasker_BCFtools(

--- a/module/snv_workflow.nf
+++ b/module/snv_workflow.nf
@@ -88,7 +88,7 @@ workflow workflow_extract_snv_annotations {
 
     // We want to do all of the annotating with the GRCh38 / hg38 reference. If
     // the liftover is going from h38 to hg19, defer until after annotations
-    if (params.liftover_forward) {
+    if (params.liftover_direction == "GRCh37ToGRCh38") {
         // Step 1: Liftover
         run_liftover_BCFtools(
             vcf_with_sample_id,

--- a/module/sv_workflow.nf
+++ b/module/sv_workflow.nf
@@ -1,5 +1,6 @@
 process liftover_annotate_SV_StableLift {
     container params.docker_image_stablelift
+    containerOptions "-v ${moduleDir}:${moduleDir}"
 
     publishDir path: "${params.output_dir_base}/intermediate/${task.process.replace(':', '/')}",
         pattern: "liftover.{vcf.gz,Rds}",

--- a/test/backward.config
+++ b/test/backward.config
@@ -1,0 +1,23 @@
+includeConfig "${projectDir}/config/default.config"
+includeConfig "${projectDir}/config/methods.config"
+includeConfig "${projectDir}/nextflow.config"
+
+includeConfig "${projectDir}/test/common.config"
+
+params {
+    // Reference files
+    funcotator_data_source = "/hot/ref/tool-specific-input/Funcotator/somatic/funcotator_dataSources.v1.7.20200521s"
+
+    liftover_direction = "GRCh38ToGRCh37"
+
+    chain_file = "/hot/ref/tool-specific-input/liftOver/hg38ToHg19.over.chain"
+
+    repeat_bed = "/hot/ref/database/RepeatMasker-3.0.1/processed/GRCh38/GRCh38_RepeatMasker_intervals.bed"
+
+    variant_caller = "Mutect2"
+
+    rf_model = "/hot/project/method/AlgorithmEvaluation/BNCH-000142-GRCh37v38/sSNV/stableLift/train_CPCG-40QC_Mutect2/RF-train_Mutect2_ntree2000_nodesize5_classratio0.Rds"
+}
+
+// Setup the pipeline config. DO NOT REMOVE THIS LINE!
+methods.setup()

--- a/test/common.config
+++ b/test/common.config
@@ -3,24 +3,6 @@ params {
 
     ucla_cds = false
 
-    // Reference files
-    funcotator_data {
-        data_source = "/hot/ref/tool-specific-input/Funcotator/somatic/funcotator_dataSources.v1.7.20200521s"
-        src_reference_id = "hg19"
-        dest_reference_id = "hg38"
-    }
-
-    // The source reference sequence (FASTA). Must correspond with
-    // params.funcotator_data.src_reference_id
-    src_fasta_ref = "/hot/ref/reference/GRCh37-EBI-hs37d5/hs37d5.fa"
-
-    // The destination reference sequence (FASTA). Must correspond with
-    // params.funcotator_data.dest_reference_id
-    dest_fasta_ref = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
-
-    // The liftover chain file between the source and destination FASTA
-    // references
-    chain_file = "/hot/ref/tool-specific-input/liftOver/hg19ToHg38.over.chain"
-
-    repeat_bed = "/hot/ref/database/RepeatMasker-3.0.1/processed/GRCh38/GRCh38_RepeatMasker_intervals.bed"
+    fasta_ref_37 = "/hot/ref/reference/GRCh37-EBI-hs37d5/hs37d5.fa"
+    fasta_ref_38 = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
 }

--- a/test/snv-backward.yaml
+++ b/test/snv-backward.yaml
@@ -1,4 +1,4 @@
 ---
-sample_id: ExampleID
+sample_id: 38-to-37-sample
 input:
   vcf: /hot/project/method/AlgorithmEvaluation/BNCH-000142-GRCh37v38/validation/TCGA-SARC_WXS/GRCh38/Mutect2/TCGA-SARC_WXS_Mutect2_merge.vcf.gz

--- a/test/snv.config
+++ b/test/snv.config
@@ -8,7 +8,17 @@ params {
     // Choices: ["Mutect2", "HaplotypeCaller"]
     variant_caller = "Mutect2"
 
+    liftover_direction = "GRCh37ToGRCh38"
+
     rf_model = "/hot/project/method/AlgorithmEvaluation/BNCH-000142-GRCh37v38/sSNV/stableLift/train_CPCG-40QC_Mutect2/RF-train_Mutect2_ntree2000_nodesize5_classratio0.Rds"
+
+    // Reference files
+    funcotator_data_source = "/hot/ref/tool-specific-input/Funcotator/somatic/funcotator_dataSources.v1.7.20200521s"
+    repeat_bed = "/hot/ref/database/RepeatMasker-3.0.1/processed/GRCh38/GRCh38_RepeatMasker_intervals.bed"
+
+    // The liftover chain file between the source and destination FASTA
+    // references
+    chain_file = "/hot/ref/tool-specific-input/liftOver/hg19ToHg38.over.chain"
 }
 
 // Setup the pipeline config. DO NOT REMOVE THIS LINE!

--- a/test/snv.yaml
+++ b/test/snv.yaml
@@ -1,4 +1,4 @@
 ---
-sample_id: ExampleID
+sample_id: 37-to-38-sample
 input:
   vcf: /hot/project/method/AlgorithmEvaluation/BNCH-000142-GRCh37v38/validation/TCGA-SARC_WGS/GRCh37/Mutect2/TCGA-SARC_WGS_Mutect2_merge.vcf.gz

--- a/test/sv.config
+++ b/test/sv.config
@@ -8,12 +8,13 @@ params {
     // Choices: ["Mutect2", "HaplotypeCaller"]
     variant_caller = "Delly2"
 
+    liftover_direction = "GRCh37ToGRCh38"
+
     rf_model = "/hot/project/method/AlgorithmEvaluation/BNCH-000142-GRCh37v38/gSV/stableLift/train_CPCG-40QC_Delly2/RF-train_Delly2_ntree2000_nodesize20_classratio0.Rds"
 
-    // FIXME Should this be bundled?
-    header_contigs = "/hot/code/nkwang/GitHub/uclahs-cds/project-method-AlgorithmEvaluation-BNCH-000142-GRCh37v38/report/manuscript/publish/GRCh38-vcf-header-contigs.txt"
+    chain_file = "/hot/ref/tool-specific-input/liftOver/hg19ToHg38.over.chain"
 
-    // FIXME Should this be bundled?
+    header_contigs = "/hot/code/nkwang/GitHub/uclahs-cds/project-method-AlgorithmEvaluation-BNCH-000142-GRCh37v38/report/manuscript/publish/GRCh38-vcf-header-contigs.txt"
     gnomad_rds = "/hot/code/nkwang/GitHub/uclahs-cds/project-method-AlgorithmEvaluation-BNCH-000142-GRCh37v38/report/manuscript/publish/data/gnomad.v4.0.sv.Rds"
 }
 


### PR DESCRIPTION
# Description

Closes #19.

This simplifies the parameter interface by hiding the following parameters from the user:

https://github.com/uclahs-cds/pipeline-StableLift/blob/70cde6086c93f5de34f5c150c5211a6caddf42aa/config/methods.config#L43-L53

Instead, the user is expected to supply:

* `liftover_direction` - must be one of `GRCh37ToGRCh38` or `GRCh38ToGRCh37`
* `fasta_ref_37`
* `fasta_ref_38`

In addition, the branch-specific parameters (`funcotator_data_sources` and `repeat_bed` for SNV, `header_contigs` and `gnomad_rds` for SV) are now conditionally required and validated based on the `variant_caller` parameter.

---

I started three parallel NFTest jobs to test, but unfortunately two of the log file names collided... weirdly, the `SV` and `SNV` jobs won in the `/hot/software/pipeline/.../log-nftest-*.log` files, but the `SV` and `SNV-backward` jobs won in my local `sbatch-nftest-*.log` files!

```console
$ head /hot/software/pipeline/pipeline-StableLift/Nextflow/development/unreleased/nwiltsie-simplify-params/*.log -n 2
==> /hot/software/pipeline/pipeline-StableLift/Nextflow/development/unreleased/nwiltsie-simplify-params/log-nftest-20240830T235010Z.log <==
2024-08-30 23:50:10,433 - NFTest - MainThread - INFO - Beginning tests...
2024-08-30 23:50:10,433 - NFTest - MainThread - INFO - SNV: None

==> /hot/software/pipeline/pipeline-StableLift/Nextflow/development/unreleased/nwiltsie-simplify-params/log-nftest-20240830T235139Z.log <==
2024-08-30 23:51:39,981 - NFTest - MainThread - INFO - Beginning tests...
2024-08-30 23:51:39,981 - NFTest - MainThread - INFO - SV: None
```

```console
$ head sbatch-nftest-20240830T234652Z.log sbatch-nftest-20240830T234651Z.log -n 6
==> sbatch-nftest-20240830T234652Z.log <==
LOG: .env not found in /hot/code/nwiltsie/pipelines/pipeline-StableLift.
LOG: .env not found in /shared/home/nwiltsie.
WARN: unable to find .env. Default values will be used.
================================ NFTEST STARTS =================================
2024-08-30 23:51:39,981 - NFTest - INFO - Beginning tests...
2024-08-30 23:51:39,981 - NFTest - INFO - SV: None

==> sbatch-nftest-20240830T234651Z.log <==
LOG: .env not found in /hot/code/nwiltsie/pipelines/pipeline-StableLift.
LOG: .env not found in /shared/home/nwiltsie.
WARN: unable to find .env. Default values will be used.
================================ NFTEST STARTS =================================
2024-08-30 23:51:39,986 - NFTest - INFO - Beginning tests...
2024-08-30 23:51:39,986 - NFTest - INFO - SNV-backward: None
```

That said, all the jobs are currently running.

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the pipeline on at least one A-mini sample.
