### PR TITLE
Fix unexpected factor renaming in SV branch

### DIFF
--- a/module/scripts/extract-VCF-features-SV.R
+++ b/module/scripts/extract-VCF-features-SV.R
@@ -254,7 +254,6 @@ all.features <- c(continuous.features, categorical.features, 'ID');
 features.dt <- features.dt[, ..all.features];
 features.dt[, (continuous.features) := lapply(.SD, as.numeric), .SDcols = continuous.features];
 features.dt[, (continuous.features) := lapply(.SD, function(x) ifelse(is.na(x), 0, x)), .SDcols = continuous.features];
-# features.dt[, (categorical.features) := lapply(.SD, function(x) ifelse(is.na(x), '', x)), .SDcols = categorical.features];
 features.dt[, (categorical.features) := lapply(.SD, as.factor), .SDcols = categorical.features];
 names(features.dt) <- make.names(names(features.dt));
 

--- a/module/scripts/extract-VCF-features-SV.R
+++ b/module/scripts/extract-VCF-features-SV.R
@@ -254,7 +254,7 @@ all.features <- c(continuous.features, categorical.features, 'ID');
 features.dt <- features.dt[, ..all.features];
 features.dt[, (continuous.features) := lapply(.SD, as.numeric), .SDcols = continuous.features];
 features.dt[, (continuous.features) := lapply(.SD, function(x) ifelse(is.na(x), 0, x)), .SDcols = continuous.features];
-features.dt[, (categorical.features) := lapply(.SD, function(x) ifelse(is.na(x), '', x)), .SDcols = categorical.features];
+# features.dt[, (categorical.features) := lapply(.SD, function(x) ifelse(is.na(x), '', x)), .SDcols = categorical.features];
 features.dt[, (categorical.features) := lapply(.SD, as.factor), .SDcols = categorical.features];
 names(features.dt) <- make.names(names(features.dt));
 


### PR DESCRIPTION
@nwiltsie can you rerun NFTest for GRCh37->GRCh38 Delly2 against the new expected output (same location)?

`/hot/project/method/AlgorithmEvaluation/BNCH-000142-GRCh37v38/test/output/TCGA-SARC_10TN-WGS_GRCh37-to-GRCh38/TCGA-SARC_10TN-WGS_GRCh37_gSV_Delly2_StableLift-GRCh38.vcf.gz`
`/hot/project/method/AlgorithmEvaluation/BNCH-000142-GRCh37v38/test/output/TCGA-SARC_10TN-WGS_GRCh37-to-GRCh38/TCGA-SARC_10TN-WGS_GRCh37_gSV_Delly2_StableLift-GRCh38_filtered.vcf.gz`