### PR TITLE
Update cluster reference paths

### DIFF
--- a/test/common.config
+++ b/test/common.config
@@ -32,7 +32,7 @@ params {
     save_intermediate_files = true
     ucla_cds = false
 
-    fasta_ref_37 = "/hot/ref/reference/GRCh37-EBI-hs37d5/hs37d5.fa"
-    fasta_ref_38 = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    fasta_ref_37 = "/hot/resource/reference-genome/GRCh37-EBI-hs37d5/hs37d5.fa"
+    fasta_ref_38 = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
     resource_bundle_path = "/hot/project/method/AlgorithmEvaluation/BNCH-000142-GRCh37v38/publish/resource"
 }


### PR DESCRIPTION
This PR updates reference paths that were renamed during the most recent cluster downtime.

I was specifically looking for single lines containing one (or more) of the following keys, so I missed any paths split across multiple lines.

| Search String                                                  |
|----------------------------------------------------------------|
| `/hot/ref/`                                                    |
| `/hot/ref/cohort/TCGA/CCG-AIM/`                                |
| `/hot/ref/cohort/TCGA/PanCanAtlas/`                            |
| `/hot/ref/database/1000Genomes/`                               |
| `/hot/ref/database/GDC-34.0 `                                  |
| `/hot/ref/database/GDC-34.0/`                                  |
| `/hot/ref/database/PCAWG/`                                     |
| `/hot/ref/database/ProstateTumor/Boutros-Yamaguchi-PRAD-CPCG/` |
| `/hot/ref/reference/`                                          |
| `/hot/resource/SMC-HET/`                                       |

A table of updated filepaths and whether or not they resolve to a file is included below. Where the original paths still exist due to symlinks I verified that they resolve to the same file as the updated path.

| Original                                                              |                    | Updated                                                                           |                    |
|-----------------------------------------------------------------------|--------------------|-----------------------------------------------------------------------------------|--------------------|
| `/hot/ref/reference/GRCh37-EBI-hs37d5/hs37d5.fa`                      | :white_check_mark: | `/hot/resource/reference-genome/GRCh37-EBI-hs37d5/hs37d5.fa`                      | :white_check_mark: |
| `/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta` | :white_check_mark: | `/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta` | :white_check_mark: |